### PR TITLE
Apksigner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -426,3 +426,8 @@ lib/cocos_old/
 lib/Dobby_old/
 sign.bat
 sign.sh
+jarsign.sh
+
+# Android NDK, build-tools
+/ndk/
+/abt/

--- a/build_release.sh
+++ b/build_release.sh
@@ -8,8 +8,9 @@ NINJA="${MT_NINJA:-ninja}" # /usr/bin/ninja
 CURL="${MT_CURL:-curl}" # /usr/bin/curl
 JAVA="${MT_JAVA:-java}" # /usr/bin/java
 PYTHON="${MT_PYTHON:-python3}" # /usr/bin/python3.8
-JARSIGNER="${MT_JARSIGNER:-jarsigner}" # /usr/bin/jarsigner
-APKTOOL="${MT_APKTOOL:-apktool_2.5.0.jar}"
+APKTOOL="${MT_APKTOOL:-apktool_2.6.0.jar}"
+ZIPALIGN="${MT_ZIPALIGN:-zipalign}" # ~/android-sdk/build-tools/zipalign
+APKSIGNER="${MT_APKSIGNER:-apksigner}" # ~/android-sdk/build-tools/apksigner
 
 # arg-based
 SRCAPK="${1:-${BASEDIR}/apk/vanilla.apk}"


### PR DESCRIPTION
Switched from jarsigner to apksigner.

Digest algo and signature algo downgraded to `SHA-256` and `SHA256withRSA, 4096-bit key`, or whatever apksigner does by default.

`zipalign` and `apksigner` must be provided in any of following ways:
1. Found within $PATH
2. Provided via env variables `MT_ZIPALIGN` and `MT_APKSIGNER`
3. Hardcoded in sign.sh (defaults to `./abt/`)

apktool bumped to 2.6.0